### PR TITLE
Add ec2:DescribeNetworkInterfaceAttribute to User policy

### DIFF
--- a/doc_source/iam.md
+++ b/doc_source/iam.md
@@ -395,6 +395,7 @@ The following example sets the ParallelClusterUserPolicy, using SGE, Slurm, or T
             "Action": [
                 "efs:DescribeMountTargets",
                 "efs:DescribeMountTargetSecurityGroups",
+                "ec2:DescribeNetworkInterfaceAttribute"
             ],
             "Effect": "Allow",
             "Resource": "*"


### PR DESCRIPTION
This fix https://github.com/aws/aws-parallelcluster/issues/1139

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
