### PR TITLE
Fixed UserPolicy permissions for FSx and EFS

### DIFF
--- a/doc_source/iam.md
+++ b/doc_source/iam.md
@@ -406,6 +406,7 @@ The following example sets the `ParallelClusterUserPolicy`, using SGE, Slurm, or
             "Action": [
                 "iam:PassRole",
                 "iam:CreateRole",
+                "iam:CreateServiceLinkedRole",
                 "iam:DeleteRole",
                 "iam:GetRole",
                 "iam:TagRole",
@@ -441,8 +442,8 @@ The following example sets the `ParallelClusterUserPolicy`, using SGE, Slurm, or
         {
             "Sid": "EFSDescribe",
             "Action": [
-                "efs:DescribeMountTargets",
-                "efs:DescribeMountTargetSecurityGroups",
+                "elasticfilesystem:DescribeMountTargets",
+                "elasticfilesystem:DescribeMountTargetSecurityGroups",
                 "ec2:DescribeNetworkInterfaceAttribute"
             ],
             "Effect": "Allow",
@@ -454,6 +455,14 @@ The following example sets the `ParallelClusterUserPolicy`, using SGE, Slurm, or
                 "ssm:GetParametersByPath"
             ],
             "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Sid": "FSx",
+            "Effect": "Allow",
+            "Action": [
+                "fsx:*"
+            ],
             "Resource": "*"
         }
     ]


### PR DESCRIPTION
*Issue #, if available:
https://github.com/aws/aws-parallelcluster/issues/1312

*Description of changes:
Added permissions required for UserPolicy to create a cluster with FSx.
Also fixed incorrect prefix for EFS related permissions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
