### PR TITLE
Fix EFS policy rules

### DIFF
--- a/doc_source/iam.md
+++ b/doc_source/iam.md
@@ -441,8 +441,8 @@ The following example sets the `ParallelClusterUserPolicy`, using SGE, Slurm, or
         {
             "Sid": "EFSDescribe",
             "Action": [
-                "efs:DescribeMountTargets",
-                "efs:DescribeMountTargetSecurityGroups",
+                "elasticfilesystem:DescribeMountTargets",
+                "elasticfilesystem:DescribeMountTargetSecurityGroups",
                 "ec2:DescribeNetworkInterfaceAttribute"
             ],
             "Effect": "Allow",


### PR DESCRIPTION
The key to use to manage EFS permissions is "elasticfilesystem", not "efs".

See: https://docs.aws.amazon.com/efs/latest/ug/access-control-managing-permissions.html
