### PR TITLE
Document AWS_PCLUSTER_CONFIG_FILE env var.

### DIFF
--- a/doc_source/configuration.md
+++ b/doc_source/configuration.md
@@ -15,7 +15,7 @@
 + [[vpc] section](vpc-section.md)
 + [Example](examples.md)
 
-By default, AWS ParallelCluster uses the file `~/.parallelcluster/config` for all configuration parameters\.
+By default, AWS ParallelCluster uses the file `~/.parallelcluster/config` for all configuration parameters\. A custom configuration file may be specified via the `--config` command line option or `AWS_PCLUSTER_CONFIG_FILE` environment variable.
 
 An example configuration file is installed with AWS ParallelCluster in the Python directory at `site-packages/aws-parallelcluster/examples/config`\. The example configuration file is also available on GitHub, at [https://github.com/aws/aws-parallelcluster/blob/v2.5.1/cli/pcluster/examples/config](https://github.com/aws/aws-parallelcluster/blob/v2.5.1/cli/pcluster/examples/config)\.
 


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-parallelcluster/issues/1579

*Description of changes:*

Add top-level documentation for custom config files via `--config` command line option or `AWS_PCLUSTER_CONFIG_FILE` env var.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
