### PR TITLE
Enable service-linked role to modify IAM roles

### DIFF
--- a/doc_source/iam.md
+++ b/doc_source/iam.md
@@ -429,7 +429,10 @@ To:
                 "iam:SimulatePrincipalPolicy"
             ],
             "Effect": "Allow",
-            "Resource": "arn:aws:iam::<AWS ACCOUNT ID>:role/<PARALLELCLUSTER EC2 ROLE NAME>"
+            "Resource": [
+                "arn:aws:iam::<AWS ACCOUNT ID>:role/<PARALLELCLUSTER EC2 ROLE NAME>",
+                "arn:aws:iam::<AWS ACCOUNT ID>:role/aws-service-role/*"
+            ]
         },
         {
             "Sid": "IAMCreateInstanceProfile",


### PR DESCRIPTION
The FSx substack creates a service-linked role, which needs to modify an account's IAM roles. This change adds the needed modification to the `ParallelClusterUserPolicy`, used to create/update/delete a cluster.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.