### PR TITLE
Add EFS Permissions

### DIFF
--- a/doc_source/iam.md
+++ b/doc_source/iam.md
@@ -480,6 +480,14 @@ To:
                 "fsx:*"
             ],
             "Resource": "*"
+        },
+        {
+            "Sid": "EFS",
+            "Effect": "Allow",
+            "Action": [
+                "elasticfilesystem:*"
+            ],
+            "Resource": "*"
         }
     ]
 }


### PR DESCRIPTION
This change adds the permissions required to create a new EFS filesystem to `ParallelClusterUserPolicy`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
