### PR TITLE
Add permissions required for CloudWatch Logs integration

### DIFF
--- a/doc_source/iam.md
+++ b/doc_source/iam.md
@@ -491,6 +491,17 @@ To:
                 "elasticfilesystem:*"
             ],
             "Resource": "*"
+        },
+        {
+            "Sid": "CloudWatchLogs",
+            "Effect": "Allow",
+            "Action": [
+                "logs:DeleteLogGroup",
+                "logs:PutRetentionPolicy",
+                "logs:DescribeLogGroups",
+                "logs:CreateLogGroup"
+            ],
+            "Resource": "*"
         }
     ]
 }


### PR DESCRIPTION
Starting with ParallelCluster 2.6.0 users need to be able to create log groups


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
