### PR TITLE
Add policy for ec2:describe_instance_types

### DIFF
--- a/doc_source/iam.md
+++ b/doc_source/iam.md
@@ -229,6 +229,7 @@ To:
                 "ec2:DescribeImages",
                 "ec2:DescribeInstances",
                 "ec2:DescribeInstanceStatus",
+                "ec2:DescribeInstanceTypes",
                 "ec2:DescribeSnapshots",
                 "ec2:DescribeVolumes",
                 "ec2:DescribeVpcAttribute",


### PR DESCRIPTION
Policy is required from the new EFA validator.

Warning: this PR should be merged only after 2.8.0 release.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
