### PR TITLE
Remove Berkshelf dependency

### DIFF
--- a/doc_source/cluster-definition.md
+++ b/doc_source/cluster-definition.md
@@ -305,7 +305,7 @@ ephemeral_dir = /scratch
 
 ## `extra_json`<a name="extra-json"></a>
 
-Defines the extra JSON that is merged into the `dna.json` that is used by Berkshelf\. For more information, see [Building a Custom AWS ParallelCluster AMI](tutorials_02_ami_customization.md)\.
+Defines the extra JSON that is merged into the Chef `dna.json`\. For more information, see [Building a Custom AWS ParallelCluster AMI](tutorials_02_ami_customization.md)\.
 
 The default value is `{}`\.
 

--- a/doc_source/pcluster.createami.md
+++ b/doc_source/pcluster.createami.md
@@ -12,7 +12,6 @@ pcluster createami [ -h ] -ai BASE_AMI_ID -os BASE_AMI_OS [ -i INSTANCE_TYPE ]
 
 In addition to the AWS ParallelCluster CLI, the following dependencies are required to run `pcluster createami`:
 + **Packer**: Download the latest version from [https://www.packer.io/downloads.html](https://www.packer.io/downloads.html)\.
-+ **Berkshelf**: Install using `gem install berkshelf`\. For more information, see the [Berkshelf website](https://github.com/berkshelf/berkshelf)\.
 
 ## Named Arguments<a name="pcluster.createami.namedarg"></a>
 

--- a/doc_source/tutorials_02_ami_customization.md
+++ b/doc_source/tutorials_02_ami_customization.md
@@ -56,11 +56,9 @@ This is the safest method, because the base AWS ParallelCluster AMI is often upd
 
 If you have a customized AMI and software already in place, you can apply the changes needed by AWS ParallelCluster on top of it\.
 
-1. Install the following tools in your local system, together with the AWS ParallelCluster CLI:
-   + Packer: find the latest version for your OS from the [Packer website](https://www.packer.io/downloads.html), and install it\.
-   + Berkshelf: Install using `gem install berkshelf`\. For more information, see the [Berkshelf website](https://github.com/berkshelf/berkshelf)\.
-
-1. Verify that the `packer` and `berks` commands are available in your PATH after you have installed the tools in Step 1\.
+1. Install the Packer tool in your local system, together with the AWS ParallelCluster CLI:
+   + find the latest version for your OS from the [Packer website](https://www.packer.io/downloads.html), and install it\.
+   + verify that the `packer` command is available in your PATH after you have installed it
 
 1. Configure your AWS account credentials so that Packer can make calls to AWS API operations on your behalf\. The minimal set of required permissions necessary for Packer to work are documented in the [IAM Task or Instance Role](https://www.packer.io/docs/builders/amazon.html#iam-task-or-instance-role) section of the *Amazon AMI Builder* topic in the Packer documentation\.
 


### PR DESCRIPTION
PCluster Cookbook vendoring has been moved on Packer instance

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
