### PR TITLE
Enable use of key through KMS console

### DIFF
--- a/doc_source/tutorials_04_encrypted_kms_fs.md
+++ b/doc_source/tutorials_04_encrypted_kms_fs.md
@@ -28,9 +28,9 @@ Next create a role:
 
 ## Give your key permissions<a name="give-your-key-permissions"></a>
 
-In the IAM Console > **Encryption Keys** > click your key\.
+In the KMS Console > **Customer managed keys** > click your key's alias or ID\.
 
-Click **Add User**, and search for the *ParallelClusterInstanceRole* you just created\. Attach it\.
+Click the **Add** button in the **Key users** box underneath the **Key policy** tab, and search for the *ParallelClusterInstanceRole* you just created\. Attach it\.
 
 ## Creating the cluster<a name="creating-the-cluster"></a>
 


### PR DESCRIPTION
Previously the instructions for encrypting EBS and FSx file systems via ParallelCluster recommended adding users for a KMS key via the IAM console. It doesn't appear this can be done via the IAM console anymore. This changes the instructions to recommend customers use the KMS console instead.

This is motivated by [aws-parallelcluster issue #1943](https://github.com/aws/aws-parallelcluster/issues/1943).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
