### PR TITLE
Improve cluster section label documentation

### DIFF
--- a/doc_source/cluster-definition.md
+++ b/doc_source/cluster-definition.md
@@ -49,11 +49,12 @@
 + [`template_url`](#template-url)
 + [`vpc_settings`](#vpc-settings)
 
-Defines one or more clusters for different job types or workloads\.
+Defines one or more cluster templates for different job types or workloads\.
 
-Each cluster can have its own configuration\.
+The same template can be used for multiple cluster creations\.
 
-The format is `[cluster cluster-name]`\. The [`[cluster]` section](#cluster-definition) named by the [`cluster_template`](global.md#cluster-template) setting in the [`[global]` section](global.md) is used by default, but can be overridden on the [`pcluster`](pcluster.md) command line\. *cluster\-name* must start with a letter, contain no more than 60 characters, and only contain letters, numbers, and hyphens \(\-\)\.
+The format is `[cluster cluster-template]`\. The [`[cluster]` section](#cluster-definition) named by the [`cluster_template`](global.md#cluster-template) setting in the [`[global]` section](global.md) is used by default when creating a cluster, but can be overridden on the [`pcluster`](pcluster.md) command line\. 
+*cluster\-template* must start with a letter, contain no more than 30 characters, and only contain letters, numbers, hyphens \(\-\) and underscores\.
 
 ```
 [cluster default]


### PR DESCRIPTION
Here we were mixing the two concepts of cluster-name and cluster-template.

We can have multiple `[cluster ...]` sections in the configuration file and the same cluster section can be used for multiple cluster creation.
E.g.
```
pcluster create test -t default
pcluster create test2 -t default
```
In the previous example we're creating two clusters named `test` and `test2` but using the same `[cluster default]` section from the configuration file.

The section name must start with a letter, contain no more than 30 characters, and only contain letters, numbers, hyphens \(\-\), and underscores \(\_\).
Instead the cluster name, that the user can pass to the `pcluster create <cluster-name>` command can contain no more than 60 characters, and only contain letters, numbers, and hyphens \(\-\). 

See https://github.com/aws/aws-parallelcluster/pull/1987 for cluster name validation 
and https://github.com/aws/aws-parallelcluster/pull/1997 for section label validation.

