### PR TITLE
Add missing "required"'s

### DIFF
--- a/doc_source/cluster-definition.md
+++ b/doc_source/cluster-definition.md
@@ -471,7 +471,7 @@ initial_queue_size = 2
 
 ## `key_name`<a name="key-name"></a>
 
-Names an existing Amazon EC2 key pair with which to enable SSH access to the instances\.
+**\(Required\)** Names an existing Amazon EC2 key pair with which to enable SSH access to the instances\.
 
 ```
 key_name = mykey
@@ -885,7 +885,7 @@ template_url = https://us-east-1-aws-parallelcluster.s3.amazonaws.com/templates/
 
 ## `vpc_settings`<a name="vpc-settings"></a>
 
-Identifies the `[vpc]` section with the Amazon VPC configuration where the cluster is deployed\. The section name must start with a letter, contain no more than 30 characters, and only contain letters, numbers, hyphens \(\-\), and underscores \(\_\)\.
+**\(Required\)** Identifies the `[vpc]` section with the Amazon VPC configuration where the cluster is deployed\. The section name must start with a letter, contain no more than 30 characters, and only contain letters, numbers, hyphens \(\-\), and underscores \(\_\)\.
 
 For more information, see the [`[vpc]` section](vpc-section.md)\.
 

--- a/doc_source/vpc-section.md
+++ b/doc_source/vpc-section.md
@@ -56,7 +56,7 @@ compute_subnet_id = subnet-xxxxxx
 
 ## `master_subnet_id`<a name="master-subnet-id"></a>
 
-**\(Optional\)** Specifies the ID of an existing subnet in which to provision the head node\.
+**\(Required\)** Specifies the ID of an existing subnet in which to provision the head node\.
 
 ```
 master_subnet_id = subnet-xxxxxx
@@ -101,7 +101,7 @@ By default, all AWS accounts are limited to five \(5\) Elastic IP addresses for 
 
 ## `vpc_id`<a name="vpc-id"></a>
 
-Specifies the ID of the Amazon VPC in which to provision the cluster\.
+**\(Required\)** Specifies the ID of the Amazon VPC in which to provision the cluster\.
 
 ```
 vpc_id = vpc-xxxxxx


### PR DESCRIPTION
Signed-off-by: Hanwen <hanwenli@amazon.com>

Add "required"'s to `key_name`, `vpc_settings`, `vpc_id`, `master_subnet_id`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
