### PR TITLE
Update ParallelclusterInstancePolicy

### DIFF
--- a/doc_source/iam.md
+++ b/doc_source/iam.md
@@ -42,7 +42,8 @@ The following example sets the `ParallelClusterInstancePolicy` using SGE, Slurm,
                 "ec2:RunInstances",
                 "ec2:TerminateInstances",
                 "ec2:DescribeLaunchTemplates",
-                "ec2:CreateTags"
+                "ec2:CreateTags",
+                "ec2:DescribeInstanceTypes"
             ],
             "Resource": [
                 "*"
@@ -179,7 +180,8 @@ The following example sets the `ParallelClusterInstancePolicy` using SGE, Slurm,
         },
         {
             "Action": [
-                "logs:CreateLogStream"
+                "logs:CreateLogStream",
+                "logs:PutLogEvents"
             ],
             "Resource": [
                 "*"


### PR DESCRIPTION
Add "ec2:DescribeInstanceTypes" and "logs:PutLogEvents".
For SGE scheduler, Daemons on the computes need to use "ec2:DescribeInstanceTypes" to provide information that the scheduler needs. 
This is needed for 2.10.0. It didn’t cause fail in the 2.9.1 cluster because in that version the daemon on the compute node gets that information from a configuration file hosted in a ParallelCluster s3 bucket rather than from the API.

Without "logs:PutLogEvents", there is no log the Cloudwatch log.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
