### PR TITLE
Reset initial_queue_size update policy

### DIFF
--- a/doc_source/cluster-definition.md
+++ b/doc_source/cluster-definition.md
@@ -499,7 +499,7 @@ Defaults to `2`\.
 initial_queue_size = 2
 ```
 
-Update policy: This setting can be changed during an update, but the compute fleet should be stopped\. Otherwise, existing nodes may be terminated\.
+Update policy: This setting can be changed during an update.
 
 ## `key_name`<a name="key-name"></a>
 


### PR DESCRIPTION
The value of `initial_queue_size` can always be safely updated because of the following considerations:

- If the value is _increased_ , the desired size can be increased as well and this will be expected
- If the value is _decreased_, the desired size is kept by the internal logic of the update command (unless the `--reset-desired` flag is used)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
