### PR TITLE
fix example to stop fleet

### DIFF
--- a/doc_source/multiple-queue-mode-slurm-user-guide-v3.md
+++ b/doc_source/multiple-queue-mode-slurm-user-guide-v3.md
@@ -139,7 +139,7 @@ AWS ParallelCluster supports the following partition states\. A Slurm partition 
 + **Stopping the compute fleet** \- When the following command is executed, all partitions are placed in the `INACTIVE` state, and the AWS ParallelCluster processes keep the partitions in the `INACTIVE` state\.
 
   ```
-  $ pcluster update-compute-fleet --cluster-name testSlurm --region eu-west-1 --status STOPPED_REQUESTED
+  $ pcluster update-compute-fleet --cluster-name testSlurm --region eu-west-1 --status STOP_REQUESTED
   ```
 + **Starting the compute fleet** \- When the following command is executed, all partitions are initially placed in the `UP` state\. However, AWS ParallelCluster processes don't keep the partition in an `UP` state\. You need to change partition states manually\. All static nodes become available after a few minutes\. Note that setting a partition to `UP` doesn't power up any dynamic capacity\.
 


### PR DESCRIPTION
*Description of changes:*
Was using this example and found out the status should be `STOP_REQUESTED` instead.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
