### PR TITLE
Add CreateServiceLinkedRole for build image policy

### DIFF
--- a/doc_source/iam-roles-in-parallelcluster-v3.md
+++ b/doc_source/iam-roles-in-parallelcluster-v3.md
@@ -525,7 +525,17 @@ Users that intend to create custom EC2 images with AWS ParallelCluster will need
             ],
             "Effect": "Allow",
             "Sid": "S3Objects"
-        }
+        },
+        {
+            "Action": "iam:CreateServiceLinkedRole",
+            "Effect": "Allow",
+            "Resource": "arn:aws:iam::*:role/aws-service-role/imagebuilder.amazonaws.com/AWSServiceRoleForImageBuilder",
+            "Condition": {
+                "StringLike": {
+                    "iam:AWSServiceName": "imagebuilder.amazonaws.com"
+                }
+            }
+        }        
     ]
 }
 ```


### PR DESCRIPTION
This policy is required to create at least once the role AWSServiceRoleForImageBuilder, which is needed to allow EC2 Image Builder to access AWS resources on user behalf.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
