### PR TITLE
3.x: Limit privileges associated with IAM Policies created within the cluster

### DIFF
--- a/doc_source/iam-roles-in-parallelcluster-v3.md
+++ b/doc_source/iam-roles-in-parallelcluster-v3.md
@@ -856,12 +856,21 @@ Here is the minimal set of policies to be used as part of this role when the sch
               "Action": [
                   "ec2:DescribeInstances",
                   "ec2:DescribeInstanceStatus",
-                  "ec2:CreateTags",
                   "ec2:DescribeVolumes",
-                  "ec2:AttachVolume",
                   "ec2:DescribeInstanceAttribute"
               ],
               "Resource": "*",
+              "Effect": "Allow"
+          },
+          {
+              "Action": [
+                  "ec2:CreateTags",
+                  "ec2:AttachVolume"
+              ],
+              "Resource": [
+                  "arn:aws:ec2:<REGION>:<AWS ACCOUNT ID>:instance/*",
+                  "arn:aws:ec2:<REGION>:<AWS ACCOUNT ID>:volume/*"
+              ],
               "Effect": "Allow"
           },
           {
@@ -962,12 +971,21 @@ Here is the minimal set of policies to be used as part of this role when the sch
               "Action": [
                   "ec2:DescribeInstances",
                   "ec2:DescribeInstanceStatus",
-                  "ec2:CreateTags",
                   "ec2:DescribeVolumes",
-                  "ec2:AttachVolume",
                   "ec2:DescribeInstanceAttribute"
               ],
               "Resource": "*",
+              "Effect": "Allow"
+          },
+          {
+              "Action": [
+                  "ec2:CreateTags",
+                  "ec2:AttachVolume"
+              ],
+              "Resource": [
+                  "arn:aws:ec2:<REGION>:<AWS ACCOUNT ID>:instance/*",
+                  "arn:aws:ec2:<REGION>:<AWS ACCOUNT ID>:volume/*"
+              ],
               "Effect": "Allow"
           },
           {

--- a/doc_source/iam-roles-in-parallelcluster-v3.md
+++ b/doc_source/iam-roles-in-parallelcluster-v3.md
@@ -888,7 +888,6 @@ Note that in case `Scheduling / SlurmQueues / Iam / InstanceRole` is used to ove
 Here is the minimal set of policies to be used as part of this role when the scheduler is AWS Batch:
 + `arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy` managed IAM policy\. For more information, see [Create IAM roles and users for use with the CloudWatch agent](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/create-iam-roles-for-cloudwatch-agent.html) in the *Amazon CloudWatch User Guide*\.
 + `arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore` managed IAM policy\. For more information, see [AWS managed policies for AWS Systems Manager](https://docs.aws.amazon.com/systems-manager/latest/userguide/security_iam_service-with-iam.html#managed-policies) in the *AWS Systems Manager User Guide*\.
-+  `arn:aws:iam::aws:policy/AWSBatchFullAccess` managed IAM policy\. For more information, see [AWS managed policy: `BatchFullAccess`](https://docs.aws.amazon.com/batch/latest/userguide/security-iam-awsmanpol.html#security-iam-awsmanpol-BatchFullAccess) in the *AWS Batch User Guide*\.
 + Additional IAM policy:
 
   ```
@@ -933,6 +932,34 @@ Here is the minimal set of policies to be used as part of this role when the sch
           },
           {
               "Action": [
+                  "batch:DescribeJobQueues",
+                  "batch:DescribeJobs",
+                  "batch:ListJobs",
+                  "batch:DescribeComputeEnvironments"
+              ],
+              "Resource": "*",
+              "Effect": "Allow"
+          },
+          {
+              "Action": [
+                  "batch:SubmitJob",
+                  "batch:TerminateJob",
+                  "logs:GetLogEvents",
+                  "ecs:ListContainerInstances",
+                  "ecs:DescribeContainerInstances",
+              ],
+              "Resource": [
+                  "arn:aws:logs:<REGION>:<AWS ACCOUNT ID>:log-group:/aws/batch/job:log-stream:PclusterJobDefinition*",
+                  "arn:aws:ecs:<REGION>:<AWS ACCOUNT ID>:container-instance/AWSBatch-PclusterComputeEnviron*",
+                  "arn:aws:ecs:<REGION>:<AWS ACCOUNT ID>:cluster/AWSBatch-Pcluster*",
+                  "arn:aws:batch:<REGION>:<AWS ACCOUNT ID>:job-queue/PclusterJobQueue*",
+                  "arn:aws:batch:<REGION>:<AWS ACCOUNT ID>:job-definition/PclusterJobDefinition*:*",
+                  "arn:aws:batch:<REGION>:<AWS ACCOUNT ID>:job/*"
+              ],
+              "Effect": "Allow"
+          },
+          {
+              "Action": [
                   "ec2:DescribeInstances",
                   "ec2:DescribeInstanceStatus",
                   "ec2:CreateTags",
@@ -948,13 +975,6 @@ Here is the minimal set of policies to be used as part of this role when the sch
                   "cloudformation:DescribeStackResource",
                   "cloudformation:DescribeStacks",
                   "cloudformation:SignalResource"
-              ],
-              "Resource": "*",
-              "Effect": "Allow"
-          },
-          {
-              "Action": [
-                  "route53:ChangeResourceRecordSets"
               ],
               "Resource": "*",
               "Effect": "Allow"

--- a/doc_source/iam-roles-in-parallelcluster-v3.md
+++ b/doc_source/iam-roles-in-parallelcluster-v3.md
@@ -1002,7 +1002,7 @@ Here is the minimal set of policies to be used as part of this role:
     {
       "Action": ["logs:CreateLogStream", "logs:PutLogEvents"],
       "Effect": "Allow",
-      "Resource": "arn:aws:logs:*:*:*"
+      "Resource": "arn:aws:logs:<REGION>:<AWS ACCOUNT ID>:log-group:/aws/lambda/pcluster-*"
     },
     {
       "Action": "ec2:DescribeInstances",


### PR DESCRIPTION
## Limit privileges for logs:CreateLogStream and logs:PutLogEvents actions
All Log groups associated with Lambda functions created within the cluster have the `pcluster-` prefix.


## Limit privileges for HeadNode role when using AWS Batch as scheduler 
`AWSBatchFullAccess` it is not required by the head node, I scoped down policies required by `aws-parallelcluster-awsbatch-cli`:
* `awsbqueues` requires `batch:DescribeJobQueues`
* `awsbstat` requires `batch:ListJobs` and `batch:DescribeJobs`
* `awsbout` requires `logs:GetLogEvents` and `batch:DescribeJobs`
* `awsbsub` requires `batch:SubmitJob`
* `awsbkill` requires `batch:TerminateJob` and `batch:DescribeJobs`
* `awsbhosts` requires `batch:DescribeComputeEnvironments`, `ecs:ListContainerInstances`, `ecs:DescribeContainerInstances` and `ec2:DescribeInstances`.

Now we can limit using `Pcluster*` prefix because I added this prefix for all AWS Batch resources.
I'm also removing useless route53 permissions from AWS Batch HeadNode policy.

--- 
Related to: https://github.com/aws/aws-parallelcluster/pull/3678

