### PR TITLE
Fix update policy for SharedStorage section

### DIFF
--- a/doc_source/SharedStorage-v3.md
+++ b/doc_source/SharedStorage-v3.md
@@ -56,7 +56,7 @@ SharedStorage:
       StorageType: string
 ```
 
-[Update policy: This setting can be changed during an update.](using-pcluster-update-cluster-v3.md#update-policy-setting-supported-v3)
+[Update policy: If this setting is changed, the update is not allowed.](using-pcluster-update-cluster-v3.md#update-policy-fail-v3)
 
 ## `SharedStorage` Properties<a name="SharedStorage-v3.properties"></a>
 


### PR DESCRIPTION
The update of the SharedStorage is not supported, it is not possible to add/remove shared storages, because it requires manual actions in the head node.
https://github.com/aws/aws-parallelcluster/blob/v3.1.2/cli/src/pcluster/schemas/cluster_schema.py#L1648


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
