### PR TITLE
[main] Add missing policies for lambda update performed through CFN

### DIFF
--- a/doc_source/iam-roles-in-parallelcluster-v3.md
+++ b/doc_source/iam-roles-in-parallelcluster-v3.md
@@ -201,7 +201,10 @@ The following policy shows the permissions required to run AWS ParallelCluster c
                 "lambda:InvokeFunction",
                 "lambda:AddPermission",
                 "lambda:RemovePermission",
-                "lambda:UpdateFunctionConfiguration"
+                "lambda:UpdateFunctionConfiguration",
+                "lambda:TagResource",
+                "lambda:ListTags",
+                "lambda:UntagResource"
             ],
             "Resource": [
                 "arn:aws:lambda:*:<AWS ACCOUNT ID>:function:parallelcluster-*",


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*
Starting from May 2022, lambda is enforcing the usage of lambda:ListTags, lambda:TagResource, and lambda:UntagResource policies to be able to perform the update of a lambda function deployed through CloudFormation



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
