### PR TITLE
[main] Add info on epilog/prolog scripts

### DIFF
--- a/doc_source/Scheduling-v3.md
+++ b/doc_source/Scheduling-v3.md
@@ -712,5 +712,11 @@ Defines a custom Route 53 hosted zone id to use for DNS name resolution for the
 [Update policy: If this setting is changed, the update is not allowed.](using-pcluster-update-cluster-v3.md#update-policy-fail-v3)
 
 `UseEc2Hostnames` \(**Optional**, `String`\)  
-Specifies the use of default EC2 hostnames\.  
+Specifies the use of default EC2 hostnames\.
+
+**Note**
+When `UseEc2Hostnames` is set to `true`, Slurm configuration file is set with ParallelCluster prolog and epilog scripts:
++ prolog is executed to add nodes info to /etc/hosts on compute nodes when each job is allocated\.
++ epilog is executed to clean contents written by prolog\.
+
 [Update policy: If this setting is changed, the update is not allowed.](using-pcluster-update-cluster-v3.md#update-policy-fail-v3)

--- a/doc_source/network-configuration-v3.md
+++ b/doc_source/network-configuration-v3.md
@@ -219,6 +219,11 @@ Scheduling:
 **Warning**  
 For clusters created with `SlurmSettings` / `Dns` / `DisableManagedDns` and `UseEc2Hostnames` set to `true`, the Slurm `NodeName` isn't resolved by the DNS\. Use the Slurm `NodeHostName` instead\.
 
+**Note**  
+When `UseEc2Hostnames` is set to `true`, Slurm configuration file is set with ParallelCluster prolog and epilog scripts:
++ prolog is executed to add nodes info to /etc/hosts on compute nodes when each job is allocated\. 
++ epilog is executed to clean contents written by prolog\.
+
 **Cluster configuration**
 
 Learn how to configure your cluster to run in a subnet with no connection to the internet\.


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*
n/A

*Description of changes:*
ParallelCluster prolog and epilog scripts are set into Slurm configuration when `UseEc2Hostnames` is set to `true`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
