### PR TITLE
[main] Add missing policies for lambda update performed through CFN (pcluster2.x)

### DIFF
--- a/doc_source/iam.md
+++ b/doc_source/iam.md
@@ -822,7 +822,9 @@ To:
                 "lambda:InvokeFunction",
                 "lambda:AddPermission",
                 "lambda:RemovePermission",
-                "lambda:TagResource"
+                "lambda:TagResource",
+                "lambda:ListTags",
+                "lambda:UntagResource"                
             ],
             "Resource": [
                 "arn:aws:lambda:<REGION>:<AWS ACCOUNT ID>:function:parallelcluster-*",


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*
n/a

*Description of changes:*
Starting from May 2022, lambda is enforcing the usage of lambda:ListTags, lambda:TagResource, and lambda:UntagResource policies to be able to perform the update of a lambda function deployed through CloudFormation


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
