### PR TITLE
Add multiple queue mode tutorial for ParallelCluster v3

### DIFF
--- a/doc_source/tutorial-mqm-v3.md
+++ b/doc_source/tutorial-mqm-v3.md
@@ -1,0 +1,285 @@
+# Multiple queue mode tutorial<a name="tutorial-mqm"></a>
+
+
+
+## Running your jobs on AWS ParallelCluster with multiple queue mode<a name="tutorial-mqm-running-jobs"></a>
+
+This tutorial walks you through running your first Hello World job on AWS ParallelCluster with [Multiple queue mode](queue-mode.md)\. If you haven't already installed AWS ParallelCluster and configured your CLI, follow the instructions in the [Setting up AWS ParallelCluster](getting_started.md) guide before continuing with this tutorial\.
+
+**Note**  
+Multiple queue mode is only supported for AWS ParallelCluster version 2\.9\.0 or later\.
+
+### Configuring your cluster<a name="tutorial-mqm-configure-cluster"></a>
+
+First, verify that AWS ParallelCluster is correctly installed by running the following command\.
+
+```
+$ pcluster version
+```
+
+For more information about `pcluster version`, see [`pcluster version`](pcluster.version-v3.md)\.
+
+This command returns the running version of AWS ParallelCluster\.
+
+Next, run `pcluster configure` to generate a basic configuration file\.
+
+```
+$ pcluster configure --config multi-queue-mode.yaml
+```
+For more information about the `pcluster configure` command, see [`pcluster configure`](pcluster.configure-v3.md)\.
+
+After you complete this step, you should have a basic configuration file named `multi-queue-mode.yaml`\. This file should contain the basic cluster configurations with subnet Ids\.
+
+This next part of the tutorial outlines how to modify your newly created configuration and launch a cluster with multiple queues\.
+
+**Note**  
+Some instances used in this tutorial aren't free\-tier eligible\.
+
+For this tutorial, use the following configuration\.
+
+```
+Region: <Your AWS Region>
+Image:
+  Os: alinux2
+HeadNode:
+  InstanceType: c5.xlarge
+  Networking:
+    SubnetId: <Head node Subnet ID>
+  Ssh:
+    KeyName: < Your key name >
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+  - Name: spot
+    ComputeResources:
+    - Name: c5xlarge
+      InstanceType: c5.xlarge
+      MinCount: 1
+      MaxCount: 10
+    - Name: t2micro
+      InstanceType: t2.micro
+      MinCount: 1
+      MaxCount: 10
+    Networking:
+      SubnetIds:
+      - <Compute nodes Subnet ID>
+  - Name: ondemand
+    ComputeResources:
+    - Name: c52xlarge
+      InstanceType: c5.2xlarge
+      MinCount: 0
+      MaxCount: 10
+    Networking:
+      SubnetIds:
+      - <Compute nodes Subnet ID>
+
+```
+
+### Creating your cluster<a name="tutorial-mqm-creating-cluster"></a>
+
+This section details how to create the multiple queue mode cluster\.
+
+```
+$ pcluster create-cluster --cluster-name multi-queue-cluster --cluster-configuration multi-queue-mode.yaml
+```
+
+For more information about `pcluster create-cluster`, see [`pcluster create-cluster`](pcluster.create-cluster-v3.md)\.
+
+After running the `pcluster create-cluster`, the following output is displayed:
+
+```
+{
+  "cluster": {
+    "clusterName": "multi-queue-cluster",
+    "cloudformationStackStatus": "CREATE_IN_PROGRESS",
+    "cloudformationStackArn": "<CLOUD_FORMATION_STACK_ARN>",
+    "region": "<REGION>",
+    "version": "<PCLUSTER_VERSION>",
+    "clusterStatus": "CREATE_IN_PROGRESS"
+  }
+}
+```
+
+You can use the following command to check if the cluster has been created\.
+
+```
+$ pcluster list-clusters
+```
+
+When the cluster is created, the `clusterStatus` field will show `CREATE_COMPLETE`\.
+
+### Logging into your head node<a name="tutorial-mqm-log-into-head-node"></a>
+
+Use your private SSH key file to log into your head node\.
+
+```
+$ pcluster ssh --cluster-name=multi-queue-cluster -i <Your key name>
+```
+
+For more information about `pcluster ssh`, see [`pcluster ssh`](pcluster.ssh-v3.md)\.
+
+After logging in, run the `sinfo` command to verify that your scheduler queues are set up and configured\.
+
+For more information about `sinfo`, see [sinfo](https://slurm.schedmd.com/sinfo.html) in the *Slurm documentation*\.
+
+```
+$ sinfo
+PARTITION AVAIL  TIMELIMIT  NODES  STATE NODELIST
+spot*        up   infinite     18  idle~ spot-dy-c5xlarge-[1-9],spot-dy-t2micro-[1-9]
+spot*        up   infinite      2   idle spot-st-c5xlarge-1,spot-st-t2micro-1
+ondemand     up   infinite     10  idle~ ondemand-dy-c52xlarge-[1-10]
+```
+
+### Running job in multiple queue mode<a name="tutorial-mqm-running-job-mqm"></a>
+
+Next, try to run a job to sleep for a while\. The job will later output its own hostname\. Make sure this script can be run by the current user\.
+
+```
+$ tee <<EOF hellojob.sh
+#!/bin/bash
+sleep 30
+echo "Hello World from $(hostname)"
+EOF
+
+$ chmod +x hellojob.sh
+$ ls -l hellojob.sh
+-rwxrwxr-x 1 ec2-user ec2-user 57 Sep 23 21:57 hellojob.sh
+```
+
+Submit the job using the `sbatch` command\. Request two nodes for this job with the `-N 2` option, and verify that the job submits successfully\. For more information about `sbatch`, see [https://slurm.schedmd.com/sbatch.html](https://slurm.schedmd.com/sbatch.html) in the *Slurm documentation*\.
+
+```
+$ sbatch -N 2 --wrap "srun hellojob.sh"
+Submitted batch job 1
+```
+
+You can view your queue and check the status of the job with the `squeue` command\. Note that, because you didn't specify a specific queue, the default queue \(`spot`\) is used\. For more information about `squeue`, see [https://slurm.schedmd.com/squeue.html](https://slurm.schedmd.com/squeue.html) in the *Slurmdocumentation*\.
+
+```
+$ squeue
+             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
+                 1      spot     wrap ec2-user  R       0:04      2 spot-st-c5xlarge-1,spot-st-t2micro-1
+```
+
+The output shows that the job is currently in a running state\. Wait 30 seconds for the job to finish, and then run `squeue` again\.
+
+```
+$ squeue
+             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
+```
+
+Now that the jobs in the queue have all finished, look for the output file `slurm-2.out` in your current directory\.
+
+```
+$ cat slurm-1.out
+Hello World from spot-st-t2micro-1
+Hello World from spot-st-c5xlarge-1
+```
+
+The output also shows that our job ran successfully on the `spot-st-c5xlarge-1` and `spot-st-t2micro-1` nodes\.
+
+Now submit the same job by specifying constraints for specific instances with the following commands\.
+
+```
+$ sbatch -N 3 -p spot -C "[c5.xlarge*1&t2.micro*2]" --wrap "srun hellojob.sh"
+Submitted batch job 2
+```
+
+You used these parameters for `sbatch`\.
++ `-N 3`– requests three nodes
++ `-p spot`– submits the job to the `spot` queue\. You can also submit a job to the `ondemand` queue by specifying `-p ondemand`\.
++ `-C "[c5.xlarge*1&t2.micro*2]"`– specifies the specific node constraints for this job\. This requests one \(1\) `c5.xlarge` node and two \(2\) `t2.micro` nodes to be used for this job\.
+
+Run the `sinfo` command to view the nodes and queues\. \(Queues in AWS ParallelCluster are called partitions in Slurm\.\)
+
+```
+$ sinfo
+PARTITION AVAIL  TIMELIMIT  NODES  STATE NODELIST
+spot*        up   infinite      1 alloc# spot-dy-t2micro-1
+spot*        up   infinite     17  idle~ spot-dy-c5xlarge-[1-9],spot-dy-t2micro-[2-9]
+spot*        up   infinite      1    mix spot-st-c5xlarge-1
+spot*        up   infinite      1  alloc spot-st-t2micro-1
+ondemand     up   infinite     10  idle~ ondemand-dy-c52xlarge-[1-10]
+```
+
+The nodes are powering up\. This is signified by the `#` suffix on the node state\. Run the squeue command to view information about the jobs in the cluster\.
+
+```
+$ squeue
+             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
+                 2      spot     wrap ec2-user CF       0:33      3 spot-dy-t2micro-1,spot-st-c5xlarge-1,spot-st-t2micro-1
+```
+
+Your job is in the `CF` \(CONFIGURING\) state, waiting for instances to scale up and join the cluster\.
+
+After about three minutes, the nodes should be available and the job enters the `R` \(RUNNING\) state\.
+
+```
+$ squeue                                                                                                                Thu May 26 13:07:25 2022
+
+             JOBID PARTITION     NAME     USER ST	TIME  NODES NODELIST(REASON)
+                 2	spot     wrap ec2-user  R	0:07	  3 spot-dy-t2micro-1,spot-st-c5xlarge-1,spot-st-t2micro-1
+```
+
+The job finishes, and all three nodes are in the `idle` state\.
+
+```
+$ squeue
+             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
+$ sinfo
+PARTITION AVAIL  TIMELIMIT  NODES  STATE NODELIST
+spot*        up   infinite     17  idle~ spot-dy-c5xlarge-[1-9],spot-dy-t2micro-[2-9]
+spot*        up   infinite      3   idle spot-dy-t2micro-1,spot-st-c5xlarge-1,spot-st-t2micro-1
+ondemand     up   infinite     10  idle~ ondemand-dy-c52xlarge-[1-10]
+```
+
+Then, after there are no jobs remaining in the queue, you can check for `slurm-3.out` in your local directory\.
+
+```
+$ cat slurm-2.out
+Hello World from spot-st-t2micro-1
+Hello World from spot-dy-t2micro-1
+Hello World from spot-st-c5xlarge-1
+```
+
+This should be the final state of the cluster:
+
+```
+$ sinfo
+PARTITION AVAIL  TIMELIMIT  NODES  STATE NODELIST
+spot*        up   infinite     17  idle~ spot-dy-c5xlarge-[1-9],spot-dy-t2micro-[2-9]
+spot*        up   infinite      3   idle spot-dy-t2micro-1,spot-st-c5xlarge-1,spot-st-t2micro-1
+ondemand     up   infinite     10  idle~ ondemand-dy-c52xlarge-[1-10]
+```
+
+After logging off of the cluster, you can clean up by running `pcluster delete-cluster`\. For more information, about `pcluster list-clusters` and `pcluster delete-cluster`, see [`pcluster list-clusters`](pcluster.list-clusters-v3.md) and [`pcluster delete-cluster`](pcluster.delete-cluster-v3.md)\.
+
+```
+$ pcluster list-clusters
+{
+  "clusters": [
+    {
+      "clusterName": "multi-queue-cluster",
+      "cloudformationStackStatus": "CREATE_COMPLETE",
+      "cloudformationStackArn": "<stack arn>",
+      "region": "eu-west-1",
+      "version": "3.1.4",
+      "clusterStatus": "CREATE_COMPLETE"
+    }
+  ]
+}
+
+$ pcluster delete-cluster -n multi-queue-cluster
+{
+  "cluster": {
+    "clusterName": "multi-queue-cluster",
+    "cloudformationStackStatus": "DELETE_IN_PROGRESS",
+    "cloudformationStackArn": "<stack arn>",
+    "region": "eu-west-1",
+    "version": "3.1.4",
+    "clusterStatus": "DELETE_IN_PROGRESS"
+  }
+}
+```
+
+For more information, see [Slurm guide for multiple queue mode](multiple-queue-mode-slurm-user-guide.md)\.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- The [docs](https://docs.aws.amazon.com/parallelcluster/latest/ug/tutorial-mqm.html) already have a tutorial on creating a multiple queue cluster using ParallelCluster v2 commands and configuration
- This commit creates the tutorial but with ParallelCluster v3 commands and configurations


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
