### PR TITLE
Remove GetSecretValue policy from Lambda and Compute node

### DIFF
--- a/doc_source/iam-roles-in-parallelcluster-v3.md
+++ b/doc_source/iam-roles-in-parallelcluster-v3.md
@@ -1097,11 +1097,6 @@ Here is the minimal set of policies to be used as part of this role:
         "arn:aws:s3:::parallelcluster-*-v1-do-not-delete",
         "arn:aws:s3:::parallelcluster-*-v1-do-not-delete/*"
       ]
-    },
-    {
-        "Action": "secretsmanager:GetSecretValue",
-        "Resource": "arn:aws:secretsmanager:<REGION>:<AWS ACCOUNT ID>:secret:<SECRET_ID>",
-        "Effect": "Allow"
     }
   ]
 }
@@ -1139,11 +1134,6 @@ Here is the minimal set of policies to be used as part of this role:
           {
               "Action": "ec2:DescribeInstanceAttribute",
               "Resource": "*",
-              "Effect": "Allow"
-          },
-          {
-              "Action": "secretsmanager:GetSecretValue",
-              "Resource": "arn:aws:secretsmanager:<REGION>:<AWS ACCOUNT ID>:secret:<SECRET_ID>",
               "Effect": "Allow"
           }
       ]


### PR DESCRIPTION
The head node requires the `GetSecretValue` policy to retrieve the read only password to use in the Active Directory integration but this is not required by the compute nodes or by the Lambda functions.
