### PR TITLE
Removing extra space in update API command

### DIFF
--- a/doc_source/api-reference-v3.md
+++ b/doc_source/api-reference-v3.md
@@ -97,7 +97,7 @@ $ API_STACK_NAME=<stack-name>  # This needs to correspond to the existing API 
 $ VERSION=3.1.4
 $ aws cloudformation update-stack \
     --region ${REGION} \
-    --stack-name ${API_STACK_NAME} \  
+    --stack-name ${API_STACK_NAME} \
     --template-url https://${REGION}-aws-parallelcluster.s3.${REGION}.amazonaws.com/parallelcluster/${VERSION}/api/parallelcluster-api.yaml \
     --capabilities CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND
 $ aws cloudformation wait stack-update-complete --stack-name ${API_STACK_NAME} --region ${REGION}


### PR DESCRIPTION
The extra space was invalidating the multi-line command syntax

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
