### PR TITLE
Add permission for CreateFleet API call

### DIFF
--- a/doc_source/iam-roles-in-parallelcluster-v3.md
+++ b/doc_source/iam-roles-in-parallelcluster-v3.md
@@ -888,7 +888,10 @@ Here is the minimal set of policies to be used as part of this role when the sch
               "Effect": "Allow"
           },
           {
-              "Action": "ec2:RunInstances",
+              "Action": [
+                   "ec2:RunInstances",
+                   "ec2:CreateFleet"
+              ],
               "Resource": "*",
               "Effect": "Allow"
           },
@@ -914,7 +917,8 @@ Here is the minimal set of policies to be used as part of this role when the sch
                   "ec2:DescribeInstances",
                   "ec2:DescribeInstanceStatus",
                   "ec2:DescribeVolumes",
-                  "ec2:DescribeInstanceAttribute"
+                  "ec2:DescribeInstanceAttribute",
+                  "ec2:DescribeCapacityReservations"
               ],
               "Resource": "*",
               "Effect": "Allow"


### PR DESCRIPTION
Add bare minimum permission to allow HeadNode to make CreateFleet requests

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
